### PR TITLE
Fix Warning by Ansible 2.0 "Using bare variables is deprecated"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,7 @@
     mode: 0644
     line: 'alias {{ item.alias }}="{{ item.command }}"'
     regexp: "^alias {{ item.alias }}="
-  with_items: bashalias_aliases
+  with_items: "{{ bashalias_aliases }}"
 
 - name: thomfab/bashalias | add include for alias file
   sudo: yes


### PR DESCRIPTION
Fixes #1